### PR TITLE
Refresh everything

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,38 @@
-FROM ubuntu:xenial
-MAINTAINER Enric Mieza <enric@enricmieza.com>
+FROM debian:bookworm
+LABEL original_maintainer="Enric Mieza <enric@enricmieza.com>" \
+      maintainer="Jan Remes <jan@remes.cz>" \
+      version="2.0.0"
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
 apt-get install -y curl \
 	apache2 \
 	libapache2-mod-php \
+	locales \
+	mariadb-server \
+	php-bz2 \
+	php-curl \
 	php-mysql \
 	php-gd \
+	php-imagick \
+	php-intl \
 	php-mbstring \
-	mysql-server && \
+	php-tidy \
+	php-xml \
+	php-zip \
+	&& \
 apt-get clean && apt-get autoclean && \
 rm -rf /var/lib/apt/lists/* && \
-rm -rf /var/www/html/* && \
-curl -o /zenphoto.tgz https://codeload.github.com/zenphoto/zenphoto/tar.gz/master && \
-sed -i "/upload_max_filesize/c\upload_max_filesize = 20M" /etc/php/7.0/apache2/php.ini && \
+rm -rf /var/www/html/*
+
+ARG ZENPHOTO_VERSION=1.6.5
+ARG PHP_VERSION=8.2
+
+RUN curl \
+	-L \
+	-o /zenphoto.tar.gz \
+	https://github.com/zenphoto/zenphoto/archive/v${ZENPHOTO_VERSION}.tar.gz && \
+sed -i "/upload_max_filesize/c\upload_max_filesize = 20M" /etc/php/${PHP_VERSION}/apache2/php.ini && \
 echo "<Directory /var/www>" >> /etc/apache2/sites-available/000-default.conf && \
 echo "	AllowOverride All" >> /etc/apache2/sites-available/000-default.conf && \
 echo "	Options -Indexes +FollowSymLinks" >> /etc/apache2/sites-available/000-default.conf && \
@@ -22,11 +40,14 @@ echo "</Directory>" >> /etc/apache2/sites-available/000-default.conf && \
 sed -i "/<\/VirtualHost>/d" /etc/apache2/sites-available/000-default.conf && \
 echo "</VirtualHost>" >> /etc/apache2/sites-available/000-default.conf
 
-ADD run.sh /run.sh
-RUN chmod 755 /run.sh
-
 EXPOSE 80
 
 VOLUME ["/var/lib/mysql"]
+VOLUME ["/var/www/html"]
 
-CMD ["/bin/bash","/run.sh"]
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && dpkg-reconfigure locales
+
+COPY run.sh /run.sh
+RUN chmod 755 /run.sh
+ENTRYPOINT ["/run.sh"]
+CMD ["apache2ctl", "-D", "FOREGROUND"]

--- a/run.sh
+++ b/run.sh
@@ -4,42 +4,48 @@ BASEDIR=/var/www/html
 # extract and initialize zenphoto if not present
 if [ ! -d $BASEDIR/zp-core ]
 then
-	rm $BASEDIR/index.html
+	rm -f $BASEDIR/index.html
 	# extract zenphoto files
-	/bin/tar xfz /zenphoto.tgz -C $BASEDIR --strip-components=1
+	tar xfz /zenphoto.tar.gz -C $BASEDIR --strip-components=1
 	# create config
-	/bin/cp $BASEDIR/zp-core/zenphoto_cfg.txt $BASEDIR/zp-data/zenphoto.cfg.php
+	cp $BASEDIR/zp-core/file-templates/zenphoto_cfg.txt $BASEDIR/zp-data/zenphoto.cfg.php
 	sed -i "/mysql_user/c\$conf['mysql_user'] = 'root';" $BASEDIR/zp-data/zenphoto.cfg.php
 	sed -i "/mysql_database/c\$conf['mysql_database'] = 'zenphoto';" $BASEDIR/zp-data/zenphoto.cfg.php
-	mkdir $BASEDIR/cache
-	mkdir $BASEDIR/cache_html
-	chown www-data $BASEDIR/albums
-	chown www-data $BASEDIR/uploaded
-	chown www-data $BASEDIR/zp-data
-	chown www-data $BASEDIR/plugins
-	chown www-data $BASEDIR/cache
-	chown www-data $BASEDIR/cache_html
+	sed -i "/mysql_pass/c\$conf['mysql_pass'] = 'zenphoto-pw';" $BASEDIR/zp-data/zenphoto.cfg.php
+	# copy .htaccess file
+	cp $BASEDIR/zp-core/file-templates/htaccess $BASEDIR/.htaccess
+	# Set permissions for files in zp-data
+	touch $BASEDIR/zp-data/debug.log
+	touch $BASEDIR/zp-data/setup.log
+	touch $BASEDIR/zp-data/charset_tést	# sic! (this name is required for charset testing)
+	chmod 0600 $BASEDIR/zp-data/*
+ 
+	chown -R www-data $BASEDIR
+	chmod -R go-rwx $BASEDIR
 fi
 
 # initialize mysql files 
 if [ ! -d /var/lib/mysql/mysql ]
 then
-	mysqld --initialize-insecure
+	mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+	
+	service mariadb start
+
+	# Wait for DB to start
+	while ! mariadb -e "USE mysql"; do
+		sleep 2
+	done
+
+	mariadb -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('zenphoto-pw');"
+	mariadb -e "FLUSH PRIVILEGES;"
 fi
 
 # run mysql daemon
-/usr/bin/mysqld_safe > /dev/null 2>&1 &
-# wait for daemon to be up
-RET=1
-while [[ RET -ne 0 ]]; do
-    echo "=> Waiting for confirmation of MySQL service startup"
-    sleep 5
-    mysql -uroot -e "status" > /dev/null 2>&1
-    RET=$?
-done
+service mariadb start
+
 # create db
 mysql -uroot -e "CREATE DATABASE zenphoto;"
 
-# run apache in foreground
-/usr/sbin/apachectl -D FOREGROUND
+# run CMD
+exec "$@"
 


### PR DESCRIPTION
This commit refreshes the container by using:
  * current Debian (Bookworm) as base
  * current Zenphoto (1.6.5)
  * current MariaDB

It also adds several PHP packages to prevent Zenphoto complaining about missing support.